### PR TITLE
Downgrade Guzzle to v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^5"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12",

--- a/src/Clients/GuzzleClient.php
+++ b/src/Clients/GuzzleClient.php
@@ -4,8 +4,10 @@ namespace PrestaShop\CircuitBreaker\Clients;
 
 use Exception;
 use GuzzleHttp\Client as OriginalGuzzleClient;
+use GuzzleHttp\Subscriber\Mock;
 use PrestaShop\CircuitBreaker\Contracts\Client;
 use PrestaShop\CircuitBreaker\Exceptions\UnavailableServiceException;
+use PrestaShop\CircuitBreaker\Exceptions\UnsupportedMethodException;
 
 /**
  * Guzzle implementation of client.
@@ -19,9 +21,22 @@ class GuzzleClient implements Client
     const DEFAULT_METHOD = 'GET';
 
     /**
+     * Supported HTTP methods
+     */
+    const SUPPORTED_METHODS = [
+        'GET' => true,
+        'HEAD' => true,
+        'POST' => true,
+        'PUT' => true,
+        'DELETE' => true,
+        'OPTIONS' => true,
+    ];
+
+    /**
      * @var array the Client main options
      */
     private $mainOptions;
+
 
     public function __construct(array $mainOptions = [])
     {
@@ -30,17 +45,22 @@ class GuzzleClient implements Client
 
     /**
      * {@inheritdoc}
+     * @throws UnavailableServiceException
      */
     public function request($resource, array $options)
     {
         try {
-            $client = new OriginalGuzzleClient($this->mainOptions);
-            $method = $this->defineMethod($options);
-            $options['http_errors'] = true;
+            $client = $this->buildClient();
+            $method = $this->getHttpMethod($options);
+            $options['exceptions'] = true;
 
-            return (string) $client->request($method, $resource, $options)->getBody();
-        } catch (Exception $exception) {
-            throw new UnavailableServiceException($exception->getMessage());
+            // prevents unhandled method errors in Guzzle 5
+            unset($options['method']);
+
+            $request = $client->createRequest($method, $resource, $options);
+            return (string) $client->send($request)->getBody();
+        } catch (Exception $e) {
+            throw new UnavailableServiceException($e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -48,17 +68,51 @@ class GuzzleClient implements Client
      * @param array $options the list of options
      *
      * @return string the method
+     * @throws UnsupportedMethodException
      */
-    private function defineMethod(array $options)
+    private function getHttpMethod(array $options)
     {
         if (isset($this->mainOptions['method'])) {
             return $this->mainOptions['method'];
         }
 
         if (isset($options['method'])) {
+            if (!array_key_exists($options['method'], self::SUPPORTED_METHODS)
+                || !self::SUPPORTED_METHODS[$options['method']]
+            ) {
+                throw UnsupportedMethodException::unsupportedMethod($options['method']);
+            }
             return $options['method'];
         }
 
         return self::DEFAULT_METHOD;
+    }
+
+    /**
+     * @return OriginalGuzzleClient
+     */
+    private function buildClient()
+    {
+        if (isset($this->mainOptions['mock']) && $this->mainOptions['mock'] instanceof Mock) {
+            return $this->buildMockClient($this->mainOptions['mock']);
+        }
+
+        return new OriginalGuzzleClient($this->mainOptions);
+    }
+
+    /**
+     * Builds a client with a mock
+     * @return OriginalGuzzleClient
+     */
+    private function buildMockClient(Mock $mock)
+    {
+        $options = $this->mainOptions;
+        unset($options['mock']);
+
+        $client = new OriginalGuzzleClient($options);
+
+        $client->getEmitter()->attach($mock);
+
+        return $client;
     }
 }

--- a/src/Clients/GuzzleClient.php
+++ b/src/Clients/GuzzleClient.php
@@ -5,7 +5,7 @@ namespace PrestaShop\CircuitBreaker\Clients;
 use Exception;
 use GuzzleHttp\Client as OriginalGuzzleClient;
 use PrestaShop\CircuitBreaker\Contracts\Client;
-use PrestaShop\CircuitBreaker\Exceptions\UnavailableService;
+use PrestaShop\CircuitBreaker\Exceptions\UnavailableServiceException;
 
 /**
  * Guzzle implementation of client.
@@ -40,7 +40,7 @@ class GuzzleClient implements Client
 
             return (string) $client->request($method, $resource, $options)->getBody();
         } catch (Exception $exception) {
-            throw new UnavailableService($exception->getMessage());
+            throw new UnavailableServiceException($exception->getMessage());
         }
     }
 

--- a/src/Contracts/Storage.php
+++ b/src/Contracts/Storage.php
@@ -2,7 +2,7 @@
 
 namespace PrestaShop\CircuitBreaker\Contracts;
 
-use PrestaShop\CircuitBreaker\Exceptions\TransactionNotFound;
+use PrestaShop\CircuitBreaker\Exceptions\TransactionNotFoundException;
 
 /**
  * Store the transaction between the Circuit Breaker
@@ -25,13 +25,11 @@ interface Storage
     /**
      * Retrieve the CircuitBreaker transaction for a specific service.
      *
-     * @var string the service name
-     *
-     * @throws TransactionNotFound
+     * @param string the service name
      *
      * @return Transaction
      *
-     * @param mixed $service
+     * @throws TransactionNotFoundException
      */
     public function getTransaction($service);
 

--- a/src/Exceptions/CircuitBreakerException.php
+++ b/src/Exceptions/CircuitBreakerException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PrestaShop\CircuitBreaker\Exceptions;
+
+use Exception;
+
+/**
+ * Base exception for Circuit Breaker exceptions
+ */
+class CircuitBreakerException extends Exception
+{
+
+}

--- a/src/Exceptions/InvalidPlaceException.php
+++ b/src/Exceptions/InvalidPlaceException.php
@@ -2,25 +2,22 @@
 
 namespace PrestaShop\CircuitBreaker\Exceptions;
 
-use Exception;
 use PrestaShop\CircuitBreaker\Utils\ErrorFormatter;
 
-final class InvalidTransaction extends Exception
+final class InvalidPlaceException extends CircuitBreakerException
 {
     /**
-     * @param mixed $service the service URI
      * @param mixed $failures the failures
-     * @param mixed $state the Circuit Breaker
+     * @param mixed $timeout the timeout
      * @param mixed $threshold the threshold
      *
      * @return self
      */
-    public static function invalidParameters($service, $failures, $state, $threshold)
+    public static function invalidSettings($failures, $timeout, $threshold)
     {
-        $exceptionMessage = 'Invalid parameters for Transaction' . PHP_EOL .
-            ErrorFormatter::format('service', $service, 'isURI', 'an URI') .
+        $exceptionMessage = 'Invalid settings for Place' . PHP_EOL .
             ErrorFormatter::format('failures', $failures, 'isPositiveInteger', 'a positive integer') .
-            ErrorFormatter::format('state', $state, 'isString', 'a string') .
+            ErrorFormatter::format('timeout', $timeout, 'isPositiveValue', 'a float') .
             ErrorFormatter::format('threshold', $threshold, 'isPositiveInteger', 'a positive integer')
         ;
 

--- a/src/Exceptions/InvalidTransactionException.php
+++ b/src/Exceptions/InvalidTransactionException.php
@@ -2,23 +2,24 @@
 
 namespace PrestaShop\CircuitBreaker\Exceptions;
 
-use Exception;
 use PrestaShop\CircuitBreaker\Utils\ErrorFormatter;
 
-final class InvalidPlace extends Exception
+final class InvalidTransactionException extends CircuitBreakerException
 {
     /**
+     * @param mixed $service the service URI
      * @param mixed $failures the failures
-     * @param mixed $timeout the timeout
+     * @param mixed $state the Circuit Breaker
      * @param mixed $threshold the threshold
      *
      * @return self
      */
-    public static function invalidSettings($failures, $timeout, $threshold)
+    public static function invalidParameters($service, $failures, $state, $threshold)
     {
-        $exceptionMessage = 'Invalid settings for Place' . PHP_EOL .
+        $exceptionMessage = 'Invalid parameters for Transaction' . PHP_EOL .
+            ErrorFormatter::format('service', $service, 'isURI', 'an URI') .
             ErrorFormatter::format('failures', $failures, 'isPositiveInteger', 'a positive integer') .
-            ErrorFormatter::format('timeout', $timeout, 'isPositiveValue', 'a float') .
+            ErrorFormatter::format('state', $state, 'isString', 'a string') .
             ErrorFormatter::format('threshold', $threshold, 'isPositiveInteger', 'a positive integer')
         ;
 

--- a/src/Exceptions/TransactionNotFound.php
+++ b/src/Exceptions/TransactionNotFound.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace PrestaShop\CircuitBreaker\Exceptions;
-
-use Exception;
-
-final class TransactionNotFound extends Exception
-{
-}

--- a/src/Exceptions/TransactionNotFoundException.php
+++ b/src/Exceptions/TransactionNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PrestaShop\CircuitBreaker\Exceptions;
+
+final class TransactionNotFoundException extends CircuitBreakerException
+{
+}

--- a/src/Exceptions/UnavailableService.php
+++ b/src/Exceptions/UnavailableService.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace PrestaShop\CircuitBreaker\Exceptions;
-
-use Exception;
-
-final class UnavailableService extends Exception
-{
-}

--- a/src/Exceptions/UnavailableServiceException.php
+++ b/src/Exceptions/UnavailableServiceException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PrestaShop\CircuitBreaker\Exceptions;
+
+final class UnavailableServiceException extends CircuitBreakerException
+{
+}

--- a/src/Exceptions/UnsupportedMethodException.php
+++ b/src/Exceptions/UnsupportedMethodException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PrestaShop\CircuitBreaker\Exceptions;
+
+/**
+ * Used when trying to use an unsupported HTTP method
+ */
+class UnsupportedMethodException extends CircuitBreakerException
+{
+
+    /**
+     * @param string $methodName
+     *
+     * @return UnsupportedMethodException
+     */
+    public static function unsupportedMethod($methodName)
+    {
+        return new static(sprintf('Unsupported method: "%s"', $methodName));
+    }
+
+}

--- a/src/Places/AbstractPlace.php
+++ b/src/Places/AbstractPlace.php
@@ -3,7 +3,7 @@
 namespace PrestaShop\CircuitBreaker\Places;
 
 use PrestaShop\CircuitBreaker\Contracts\Place;
-use PrestaShop\CircuitBreaker\Exceptions\InvalidPlace;
+use PrestaShop\CircuitBreaker\Exceptions\InvalidPlaceException;
 use PrestaShop\CircuitBreaker\Utils\Assert;
 
 abstract class AbstractPlace implements Place
@@ -85,9 +85,9 @@ abstract class AbstractPlace implements Place
      * @param float $timeout the timeout should be a positive value
      * @param int $threshold the threshold should be a positive value
      *
-     * @throws InvalidPlace
-     *
      * @return bool true if valid
+     * @throws InvalidPlaceException
+     *
      */
     private function validate($failures, $timeout, $threshold)
     {
@@ -100,6 +100,6 @@ abstract class AbstractPlace implements Place
             return true;
         }
 
-        throw InvalidPlace::invalidSettings($failures, $timeout, $threshold);
+        throw InvalidPlaceException::invalidSettings($failures, $timeout, $threshold);
     }
 }

--- a/src/SimpleCircuitBreaker.php
+++ b/src/SimpleCircuitBreaker.php
@@ -6,7 +6,7 @@ use PrestaShop\CircuitBreaker\Contracts\Place;
 use PrestaShop\CircuitBreaker\Contracts\Client;
 use PrestaShop\CircuitBreaker\Systems\MainSystem;
 use PrestaShop\CircuitBreaker\Storages\SimpleArray;
-use PrestaShop\CircuitBreaker\Exceptions\UnavailableService;
+use PrestaShop\CircuitBreaker\Exceptions\UnavailableServiceException;
 
 /**
  * Main implementation of Circuit Breaker.
@@ -44,7 +44,7 @@ final class SimpleCircuitBreaker extends PartialCircuitBreaker
             $this->moveStateTo(States::CLOSED_STATE, $service);
 
             return $response;
-        } catch (UnavailableService $exception) {
+        } catch (UnavailableServiceException $exception) {
             $transaction->incrementFailures();
             $this->storage->saveTransaction($service, $transaction);
 

--- a/src/Storages/SimpleArray.php
+++ b/src/Storages/SimpleArray.php
@@ -4,7 +4,7 @@ namespace PrestaShop\CircuitBreaker\Storages;
 
 use PrestaShop\CircuitBreaker\Contracts\Storage;
 use PrestaShop\CircuitBreaker\Contracts\Transaction;
-use PrestaShop\CircuitBreaker\Exceptions\TransactionNotFound;
+use PrestaShop\CircuitBreaker\Exceptions\TransactionNotFoundException;
 
 /**
  * Very simple implementation of Storage using a simple PHP array.
@@ -39,7 +39,7 @@ final class SimpleArray implements Storage
             return self::$transactions[$key];
         }
 
-        throw new TransactionNotFound();
+        throw new TransactionNotFoundException();
     }
 
     /**

--- a/src/Storages/SymfonyCache.php
+++ b/src/Storages/SymfonyCache.php
@@ -4,7 +4,7 @@ namespace PrestaShop\CircuitBreaker\Storages;
 
 use PrestaShop\CircuitBreaker\Contracts\Storage;
 use PrestaShop\CircuitBreaker\Contracts\Transaction;
-use PrestaShop\CircuitBreaker\Exceptions\TransactionNotFound;
+use PrestaShop\CircuitBreaker\Exceptions\TransactionNotFoundException;
 use Psr\SimpleCache\CacheInterface;
 
 /**
@@ -43,7 +43,7 @@ final class SymfonyCache implements Storage
             return $this->symfonyCache->get($key);
         }
 
-        throw new TransactionNotFound();
+        throw new TransactionNotFoundException();
     }
 
     /**

--- a/src/SymfonyCircuitBreaker.php
+++ b/src/SymfonyCircuitBreaker.php
@@ -7,7 +7,7 @@ use PrestaShop\CircuitBreaker\Contracts\System;
 use PrestaShop\CircuitBreaker\Contracts\Storage;
 use PrestaShop\CircuitBreaker\Events\TransitionEvent;
 use PrestaShop\CircuitBreaker\Contracts\ConfigurableCall;
-use PrestaShop\CircuitBreaker\Exceptions\UnavailableService;
+use PrestaShop\CircuitBreaker\Exceptions\UnavailableServiceException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -72,7 +72,7 @@ final class SymfonyCircuitBreaker extends PartialCircuitBreaker implements Confi
             );
 
             return $response;
-        } catch (UnavailableService $exception) {
+        } catch (UnavailableServiceException $exception) {
             $transaction->incrementFailures();
             $this->storage->saveTransaction($service, $transaction);
 

--- a/src/Transactions/SimpleTransaction.php
+++ b/src/Transactions/SimpleTransaction.php
@@ -5,7 +5,7 @@ namespace PrestaShop\CircuitBreaker\Transactions;
 use DateTime;
 use PrestaShop\CircuitBreaker\Contracts\Place;
 use PrestaShop\CircuitBreaker\Contracts\Transaction;
-use PrestaShop\CircuitBreaker\Exceptions\InvalidTransaction;
+use PrestaShop\CircuitBreaker\Exceptions\InvalidTransactionException;
 use PrestaShop\CircuitBreaker\Utils\Assert;
 
 /**
@@ -134,9 +134,9 @@ final class SimpleTransaction implements Transaction
      * @param string $state the Circuit Breaker state
      * @param int $threshold the threshold should be a positive value
      *
-     * @throws InvalidTransaction
-     *
      * @return bool true if valid
+     * @throws InvalidTransactionException
+     *
      */
     private function validate($service, $failures, $state, $threshold)
     {
@@ -150,6 +150,6 @@ final class SimpleTransaction implements Transaction
             return true;
         }
 
-        throw InvalidTransaction::invalidParameters($service, $failures, $state, $threshold);
+        throw InvalidTransactionException::invalidParameters($service, $failures, $state, $threshold);
     }
 }

--- a/tests/CircuitBreakerTestCase.php
+++ b/tests/CircuitBreakerTestCase.php
@@ -2,13 +2,13 @@
 
 namespace Tests\PrestaShop\CircuitBreaker;
 
+use GuzzleHttp\Message\Request;
+use GuzzleHttp\Message\Response;
+use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Subscriber\Mock;
 use PrestaShop\CircuitBreaker\Clients\GuzzleClient;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Handler\MockHandler;
 use PHPUnit\Framework\TestCase;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Request;
 
 /**
  * Helper to get a fake Guzzle client.
@@ -23,14 +23,12 @@ abstract class CircuitBreakerTestCase extends TestCase
      */
     protected function getTestClient()
     {
-        $mock = new MockHandler([
+        $mock = new Mock([
             new RequestException('Service unavailable', new Request('GET', 'test')),
             new RequestException('Service unavailable', new Request('GET', 'test')),
-            new Response(200, [], '{"hello": "world"}'),
+            new Response(200, [], Stream::factory('{"hello": "world"}')),
         ]);
 
-        $handler = HandlerStack::create($mock);
-
-        return new GuzzleClient(['handler' => $handler]);
+        return new GuzzleClient(['mock' => $mock]);
     }
 }

--- a/tests/Clients/GuzzleClientTest.php
+++ b/tests/Clients/GuzzleClientTest.php
@@ -4,7 +4,7 @@ namespace Tests\PrestaShop\CircuitBreaker\Clients;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\CircuitBreaker\Clients\GuzzleClient;
-use PrestaShop\CircuitBreaker\Exceptions\UnavailableService;
+use PrestaShop\CircuitBreaker\Exceptions\UnavailableServiceException;
 
 class GuzzleClientTest extends TestCase
 {
@@ -19,7 +19,7 @@ class GuzzleClientTest extends TestCase
 
     public function testWrongRequestThrowsAnException()
     {
-        $this->expectException(UnavailableService::class);
+        $this->expectException(UnavailableServiceException::class);
 
         $client = new GuzzleClient();
         $client->request('http://not-even-a-valid-domain.xxx', []);

--- a/tests/Exceptions/InvalidPlaceTest.php
+++ b/tests/Exceptions/InvalidPlaceTest.php
@@ -3,15 +3,15 @@
 namespace Tests\PrestaShop\CircuitBreaker\Exceptions;
 
 use PHPUnit\Framework\TestCase;
-use PrestaShop\CircuitBreaker\Exceptions\InvalidPlace;
+use PrestaShop\CircuitBreaker\Exceptions\InvalidPlaceException;
 
 class InvalidPlaceTest extends TestCase
 {
     public function testCreation()
     {
-        $invalidPlace = new InvalidPlace();
+        $invalidPlace = new InvalidPlaceException();
 
-        $this->assertInstanceOf(InvalidPlace::class, $invalidPlace);
+        $this->assertInstanceOf(InvalidPlaceException::class, $invalidPlace);
     }
 
     /**
@@ -22,7 +22,7 @@ class InvalidPlaceTest extends TestCase
      */
     public function testInvalidSettings($settings, $expectedExceptionMessage)
     {
-        $invalidPlace = InvalidPlace::invalidSettings(
+        $invalidPlace = InvalidPlaceException::invalidSettings(
             $settings[0], // failures
             $settings[1], // timeout
             $settings[2]  // threshold

--- a/tests/Exceptions/InvalidTransactionTest.php
+++ b/tests/Exceptions/InvalidTransactionTest.php
@@ -3,15 +3,15 @@
 namespace Tests\PrestaShop\CircuitBreaker\Exceptions;
 
 use PHPUnit\Framework\TestCase;
-use PrestaShop\CircuitBreaker\Exceptions\InvalidTransaction;
+use PrestaShop\CircuitBreaker\Exceptions\InvalidTransactionException;
 
 class InvalidTransactionTest extends TestCase
 {
     public function testCreation()
     {
-        $invalidPlace = new InvalidTransaction();
+        $invalidPlace = new InvalidTransactionException();
 
-        $this->assertInstanceOf(InvalidTransaction::class, $invalidPlace);
+        $this->assertInstanceOf(InvalidTransactionException::class, $invalidPlace);
     }
 
     /**
@@ -22,7 +22,7 @@ class InvalidTransactionTest extends TestCase
      */
     public function testInvalidParameters($parameters, $expectedExceptionMessage)
     {
-        $invalidPlace = InvalidTransaction::invalidParameters(
+        $invalidPlace = InvalidTransactionException::invalidParameters(
             $parameters[0], // service
             $parameters[1], // failures
             $parameters[2], // state

--- a/tests/Places/ClosedPlaceTest.php
+++ b/tests/Places/ClosedPlaceTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\PrestaShop\CircuitBreaker\Places;
 
-use PrestaShop\CircuitBreaker\Exceptions\InvalidPlace;
+use PrestaShop\CircuitBreaker\Exceptions\InvalidPlaceException;
 use PrestaShop\CircuitBreaker\Places\ClosedPlace;
 use PrestaShop\CircuitBreaker\States;
 
@@ -33,7 +33,7 @@ class ClosedPlaceTest extends PlaceTestCase
      */
     public function testCreationWithInvalidValues($failures, $timeout, $threshold)
     {
-        $this->expectException(InvalidPlace::class);
+        $this->expectException(InvalidPlaceException::class);
 
         new ClosedPlace($failures, $timeout, $threshold);
     }

--- a/tests/Places/HalfOpenPlaceTest.php
+++ b/tests/Places/HalfOpenPlaceTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\PrestaShop\CircuitBreaker\Places;
 
-use PrestaShop\CircuitBreaker\Exceptions\InvalidPlace;
+use PrestaShop\CircuitBreaker\Exceptions\InvalidPlaceException;
 use PrestaShop\CircuitBreaker\Places\HalfOpenPlace;
 use PrestaShop\CircuitBreaker\States;
 
@@ -33,7 +33,7 @@ class HalfOpenPlaceTest extends PlaceTestCase
      */
     public function testCreationWithInvalidValues($failures, $timeout, $threshold)
     {
-        $this->expectException(InvalidPlace::class);
+        $this->expectException(InvalidPlaceException::class);
 
         new HalfOpenPlace($failures, $timeout, $threshold);
     }

--- a/tests/Places/OpenPlaceTest.php
+++ b/tests/Places/OpenPlaceTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\PrestaShop\CircuitBreaker\Places;
 
-use PrestaShop\CircuitBreaker\Exceptions\InvalidPlace;
+use PrestaShop\CircuitBreaker\Exceptions\InvalidPlaceException;
 use PrestaShop\CircuitBreaker\Places\OpenPlace;
 use PrestaShop\CircuitBreaker\States;
 
@@ -33,7 +33,7 @@ class OpenPlaceTest extends PlaceTestCase
      */
     public function testCreationWithInvalidValues($failures, $timeout, $threshold)
     {
-        $this->expectException(InvalidPlace::class);
+        $this->expectException(InvalidPlaceException::class);
 
         new OpenPlace($failures, $timeout, $threshold);
     }

--- a/tests/Storages/SimpleArrayTest.php
+++ b/tests/Storages/SimpleArrayTest.php
@@ -4,7 +4,7 @@ namespace Tests\PrestaShop\CircuitBreaker\Storages;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\CircuitBreaker\Contracts\Transaction;
-use PrestaShop\CircuitBreaker\Exceptions\TransactionNotFound;
+use PrestaShop\CircuitBreaker\Exceptions\TransactionNotFoundException;
 use PrestaShop\CircuitBreaker\Storages\SimpleArray;
 
 class SimpleArrayTest extends TestCase
@@ -86,7 +86,7 @@ class SimpleArrayTest extends TestCase
      */
     public function testGetNotFoundTransactionThrowsAnException()
     {
-        $this->expectException(TransactionNotFound::class);
+        $this->expectException(TransactionNotFoundException::class);
 
         $simpleArray = new SimpleArray();
         $simpleArray->getTransaction('http://test.com');

--- a/tests/Storages/SymfonyCacheTest.php
+++ b/tests/Storages/SymfonyCacheTest.php
@@ -4,7 +4,7 @@ namespace Tests\PrestaShop\CircuitBreaker\Storages;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\CircuitBreaker\Contracts\Transaction;
-use PrestaShop\CircuitBreaker\Exceptions\TransactionNotFound;
+use PrestaShop\CircuitBreaker\Exceptions\TransactionNotFoundException;
 use PrestaShop\CircuitBreaker\Storages\SymfonyCache;
 use Symfony\Component\Cache\Simple\FilesystemCache;
 
@@ -89,7 +89,7 @@ class SymfonyCacheTest extends TestCase
      */
     public function testGetNotFoundTransactionThrowsAnException()
     {
-        $this->expectException(TransactionNotFound::class);
+        $this->expectException(TransactionNotFoundException::class);
 
         $this->symfonyCache->getTransaction('http://test.com');
     }
@@ -106,7 +106,7 @@ class SymfonyCacheTest extends TestCase
 
         // We have stored 2 transactions
         $this->assertTrue($this->symfonyCache->clear());
-        $this->expectException(TransactionNotFound::class);
+        $this->expectException(TransactionNotFoundException::class);
 
         $this->symfonyCache->getTransaction('http://a.com');
     }


### PR DESCRIPTION
This is needed to allow this library to be compatible with PrestaShop 1.7

Also, I added an "Exception" suffix to all exception classes and made them inherit from `CircuitBreakerException`.

All tests are green on my end.