### PR TITLE
Fix a few errors reported by phpqa

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -31,5 +31,5 @@ action "PHPQA" {
   needs="PHP-CS-Fixer"
   uses = "docker://mickaelandrieu/phpqa-ga"
   secrets = ["GITHUB_TOKEN"]
-  args = "--report --tools phpcs:0,phpmd:0,phpcpd:0,parallel-lint:0,phpmetrics,phploc,pdepend --ignoredDirs vendor"
+  args = "--report --tools phpcs:0,phpmd:0,phpcpd:0,parallel-lint:0,phpmetrics,phploc,pdepend --ignoredDirs vendor,tests"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
 
 script:
   - composer test -- --coverage-clover=coverage.xml
+  - composer phpcs
   - composer psalm
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ composer test
 ## Code quality
 
 ```
-composer cs-fix && composer psalm
+composer cs-fix && composer phpcb && composer psalm && composer phpcs
 ```
 
 We also use [PHPQA](https://github.com/EdgedesignCZ/phpqa#phpqa) to check the Code quality
@@ -146,12 +146,12 @@ during the CI management of the contributions.
 If you want to use it (using Docker):
 
 ```
-docker run --rm -u $UID -v $(pwd):/app eko3alpha/docker-phpqa --report --ignoredDirs vendor
+docker run --rm -u $UID -v $(pwd):/app eko3alpha/docker-phpqa --report --ignoredDirs vendor,tests
 ```
 
 If you want to use it (using Composer):
 
 ```
 composer global require edgedesign/phpqa=v1.20.0 --update-no-dev
-phpqa --report --ignoredDirs vendor
+phpqa --report --ignoredDirs vendor,tests
 ```

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "doctrine/cache": "^1.6.0",
         "symfony/cache": "^3.4.0",
         "symfony/event-dispatcher": "^3.4",
-        "vimeo/psalm": "^1.1"
+        "vimeo/psalm": "^1.1",
+        "squizlabs/php_codesniffer": "3.*"
     },
     "suggest": {
         "symfony/cache": "Allows use of Symfony Cache adapters to store transactions",
@@ -46,6 +47,8 @@
             "@php ./vendor/bin/psalm --init",
             "@php ./vendor/bin/psalm --find-dead-code --threads=8 --diff"
         ],
+        "phpcs": "@php ./vendor/bin/phpcs -p --standard=PSR2  --ignore=\"vendor/*\" \"./\" --extensions=php",
+        "phpcbf": "@php ./vendor/bin/phpcbf -p --standard=PSR2  --ignore=\"vendor/*\" \"./\" --extensions=php",
         "cs-fix": "@php ./vendor/bin/php-cs-fixer fix",
         "test": "@php ./vendor/bin/phpunit"
     },

--- a/src/AdvancedCircuitBreakerFactory.php
+++ b/src/AdvancedCircuitBreakerFactory.php
@@ -32,11 +32,11 @@ final class AdvancedCircuitBreakerFactory implements FactoryInterface
         $system = new MainSystem($closedPlace, $halfOpenPlace, $openPlace);
 
         /** @var ClientInterface $client */
-        $client = null !== $settings->getClient() ? $settings->getClient() : new GuzzleClient($settings->getClientOptions());
+        $client = $settings->getClient() ?: new GuzzleClient($settings->getClientOptions());
         /** @var StorageInterface $storage */
-        $storage = null !== $settings->getStorage() ? $settings->getStorage() : new SimpleArray();
+        $storage = $settings->getStorage() ?: new SimpleArray();
         /** @var TransitionDispatcherInterface $dispatcher */
-        $dispatcher = null !== $settings->getDispatcher() ? $settings->getDispatcher() : new NullDispatcher();
+        $dispatcher = $settings->getDispatcher() ?: new NullDispatcher();
 
         $circuitBreaker = new AdvancedCircuitBreaker(
             $system,

--- a/src/SimpleCircuitBreakerFactory.php
+++ b/src/SimpleCircuitBreakerFactory.php
@@ -26,7 +26,7 @@ final class SimpleCircuitBreakerFactory implements FactoryInterface
         $halfOpenPlace = new HalfOpenPlace($settings->getFailures(), $settings->getStrippedTimeout(), 0);
 
         /** @var ClientInterface $client */
-        $client = null !== $settings->getClient() ? $settings->getClient() : new GuzzleClient($settings->getClientOptions());
+        $client = $settings->getClient() ?: new GuzzleClient($settings->getClientOptions());
 
         return new SimpleCircuitBreaker(
             $openPlace,

--- a/tests/AdvancedCircuitBreakerFactoryTest.php
+++ b/tests/AdvancedCircuitBreakerFactoryTest.php
@@ -92,7 +92,8 @@ class AdvancedCircuitBreakerFactoryTest extends TestCase
         $circuitBreaker = $factory->create($settings);
 
         $this->assertInstanceOf(AdvancedCircuitBreaker::class, $circuitBreaker);
-        $circuitBreaker->call($localeService, $expectedParameters, function () {});
+        $circuitBreaker->call($localeService, $expectedParameters, function () {
+        });
     }
 
     public function testCircuitBreakerWithStorage()
@@ -117,7 +118,9 @@ class AdvancedCircuitBreakerFactoryTest extends TestCase
     {
         $factory = new AdvancedCircuitBreakerFactory();
         $settings = new FactorySettings(2, 0.1, 10);
-        $settings->setDefaultFallback(function () { return 'default_fallback'; });
+        $settings->setDefaultFallback(function () {
+            return 'default_fallback';
+        });
         $circuitBreaker = $factory->create($settings);
 
         $this->assertInstanceOf(AdvancedCircuitBreaker::class, $circuitBreaker);

--- a/tests/AdvancedCircuitBreakerTest.php
+++ b/tests/AdvancedCircuitBreakerTest.php
@@ -103,7 +103,9 @@ class AdvancedCircuitBreakerTest extends CircuitBreakerTestCase
             new NullDispatcher()
         );
 
-        $response = $circuitBreaker->call('anything', [], function () { return false; });
+        $response = $circuitBreaker->call('anything', [], function () {
+            return false;
+        });
         $this->assertSame(State::CLOSED_STATE, $circuitBreaker->getState());
         $this->assertEquals(0, $mock->count());
         $this->assertEquals('{"hello": "world"}', $response);
@@ -130,7 +132,9 @@ class AdvancedCircuitBreakerTest extends CircuitBreakerTestCase
             new NullDispatcher()
         );
 
-        $response = $circuitBreaker->call('anything', [], function () { return false; });
+        $response = $circuitBreaker->call('anything', [], function () {
+            return false;
+        });
         $this->assertEquals(0, $mock->count());
         $this->assertEquals(false, $response);
         $this->assertSame(State::OPEN_STATE, $circuitBreaker->getState());
@@ -185,20 +189,26 @@ class AdvancedCircuitBreakerTest extends CircuitBreakerTestCase
             new NullDispatcher()
         );
 
-        $response = $circuitBreaker->call('anything', [], function () { return false; });
+        $response = $circuitBreaker->call('anything', [], function () {
+            return false;
+        });
         $this->assertEquals(1, $mock->count());
         $this->assertEquals(false, $response);
         $this->assertSame(State::OPEN_STATE, $circuitBreaker->getState());
 
         //Stay in OPEN state
-        $response = $circuitBreaker->call('anything', [], function () { return false; });
+        $response = $circuitBreaker->call('anything', [], function () {
+            return false;
+        });
         $this->assertEquals(1, $mock->count());
         $this->assertEquals(false, $response);
         $this->assertSame(State::OPEN_STATE, $circuitBreaker->getState());
 
         sleep(2);
         //Switch to CLOSED state on success
-        $response = $circuitBreaker->call('anything', [], function () { return false; });
+        $response = $circuitBreaker->call('anything', [], function () {
+            return false;
+        });
         $this->assertEquals(0, $mock->count());
         $this->assertEquals('{"hello": "world"}', $response);
         $this->assertSame(State::CLOSED_STATE, $circuitBreaker->getState());
@@ -226,20 +236,26 @@ class AdvancedCircuitBreakerTest extends CircuitBreakerTestCase
             new NullDispatcher()
         );
 
-        $response = $circuitBreaker->call('anything', [], function () { return false; });
+        $response = $circuitBreaker->call('anything', [], function () {
+            return false;
+        });
         $this->assertEquals(1, $mock->count());
         $this->assertEquals(false, $response);
         $this->assertSame(State::OPEN_STATE, $circuitBreaker->getState());
 
         //Stay in OPEN state
-        $response = $circuitBreaker->call('anything', [], function () { return false; });
+        $response = $circuitBreaker->call('anything', [], function () {
+            return false;
+        });
         $this->assertEquals(1, $mock->count());
         $this->assertEquals(false, $response);
         $this->assertSame(State::OPEN_STATE, $circuitBreaker->getState());
 
         sleep(2);
         //Switch to OPEN state on failure
-        $response = $circuitBreaker->call('anything', [], function () { return false; });
+        $response = $circuitBreaker->call('anything', [], function () {
+            return false;
+        });
         $this->assertEquals(0, $mock->count());
         $this->assertEquals(false, $response);
         $this->assertSame(State::OPEN_STATE, $circuitBreaker->getState());

--- a/tests/CircuitBreakerWorkflowTest.php
+++ b/tests/CircuitBreakerWorkflowTest.php
@@ -162,7 +162,9 @@ class CircuitBreakerWorkflowTest extends CircuitBreakerTestCase
             new NullDispatcher()
         );
         $this->assertEquals(State::CLOSED_STATE, $firstCircuitBreaker->getState());
-        $firstCircuitBreaker->call('fake_service', [], function () { return false; });
+        $firstCircuitBreaker->call('fake_service', [], function () {
+            return false;
+        });
         $this->assertEquals(State::OPEN_STATE, $firstCircuitBreaker->getState());
         $this->assertTrue($storage->hasTransaction('fake_service'));
 
@@ -173,7 +175,9 @@ class CircuitBreakerWorkflowTest extends CircuitBreakerTestCase
             new NullDispatcher()
         );
         $this->assertEquals(State::CLOSED_STATE, $secondCircuitBreaker->getState());
-        $secondCircuitBreaker->call('fake_service', [], function () { return false; });
+        $secondCircuitBreaker->call('fake_service', [], function () {
+            return false;
+        });
         $this->assertEquals(State::OPEN_STATE, $secondCircuitBreaker->getState());
     }
 


### PR DESCRIPTION
Fix a few errors reported by phpqa
Ignore tests dir for phpqa to avoid coupling errors not relevant on a test class
