### PR TITLE
Put php-dev-tools in require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^7.3",
-        "prestashop/php-dev-tools": "^4.0"
+        "guzzlehttp/guzzle": "^7.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8",
         "doctrine/cache": "^1.10.2",
         "symfony/cache": "^4.4",
         "symfony/event-dispatcher": "^4.4",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0",
+        "prestashop/php-dev-tools": "^4.1"
     },
     "suggest": {
         "symfony/cache": "Allows use of Symfony Cache adapters to store transactions",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | `prestashop/php-dev-tools` was not in `require-dev`, this could lead to more conflicts when requiring `circuit-breaker` on other projects.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | I don't think this needs to be tested
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
