### PR TITLE
Update Symfony client compatibility in composer.json, minimum compatibility for PHP is no 7.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,11 +19,14 @@ jobs:
       - name: PHP CS Fixer
         run: ./vendor/bin/php-cs-fixer fix --dry-run
 
+      - name: Run ergebnis/composer-normalize
+        run: composer normalize --dry-run --no-check-lock
+
   tests-common:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -52,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -81,19 +84,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         symfony-http-client-versions: ['5.4', '6.0', '6.1', '6.2', '6.3', '6.4']
         exclude:
-          - php-versions: '7.2'
-            symfony-http-client-versions: '6.0'
-          - php-versions: '7.3'
-            symfony-http-client-versions: '6.0'
           - php-versions: '7.4'
             symfony-http-client-versions: '6.0'
-          - php-versions: '7.2'
-            symfony-http-client-versions: '6.1'
-          - php-versions: '7.3'
-            symfony-http-client-versions: '6.1'
           - php-versions: '7.4'
             symfony-http-client-versions: '6.1'
           - php-versions: '8.0'
@@ -114,10 +109,6 @@ jobs:
             symfony-http-client-versions: '6.3'
           - php-versions: '8.0'
             symfony-http-client-versions: '6.3'
-          - php-versions: '7.2'
-            symfony-http-client-versions: '6.4'
-          - php-versions: '7.3'
-            symfony-http-client-versions: '6.4'
           - php-versions: '7.4'
             symfony-http-client-versions: '6.4'
           - php-versions: '8.0'

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "prestashop/circuit-breaker",
     "description": "A circuit breaker implementation for PHP",
-    "type": "library",
     "license": "MIT",
+    "type": "library",
     "authors": [
         {
             "name": "PrestaShop SA",
@@ -14,23 +14,24 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
-        "symfony/http-client": "^5.4"
+        "php": ">=7.4",
+        "ergebnis/composer-normalize": "^2.44",
+        "symfony/http-client": "^5.4 || ^6"
     },
     "require-dev": {
+        "doctrine/cache": "^1.10.2",
         "guzzlehttp/guzzle": "^7.3",
         "phpunit/phpunit": "^8",
-        "doctrine/cache": "^1.10.2",
-        "symfony/cache": "^4.4",
-        "symfony/event-dispatcher": "^4.4",
+        "prestashop/php-dev-tools": "^4.1",
         "psr/simple-cache": "^1.0",
-        "prestashop/php-dev-tools": "^4.1"
+        "symfony/cache": "^4.4",
+        "symfony/event-dispatcher": "^4.4"
     },
     "suggest": {
-        "symfony/cache": "Allows use of Symfony Cache adapters to store transactions",
-        "doctrine/cache": "Allows use of Doctrine Cache adapters to store transactions",
         "ext-apcu": "Allows use of APCu adapter (performant) to store transactions",
-        "guzzlehttp/guzzle": "Allows use of Guzzle to perform HTTP requests instead of Symfony HttpClient"
+        "doctrine/cache": "Allows use of Doctrine Cache adapters to store transactions",
+        "guzzlehttp/guzzle": "Allows use of Guzzle to perform HTTP requests instead of Symfony HttpClient",
+        "symfony/cache": "Allows use of Symfony Cache adapters to store transactions"
     },
     "autoload": {
         "psr-4": {
@@ -40,6 +41,11 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\PrestaShop\\CircuitBreaker\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
         }
     },
     "scripts": {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Update Symfony client compatibility in composer.json, or the latest version is not available for update via composer for v9
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | ~
| How to test?      | ~
